### PR TITLE
 Reverted waitForAck change done by Sam, and some other minor changes

### DIFF
--- a/src/ant/core/driver.py
+++ b/src/ant/core/driver.py
@@ -106,7 +106,7 @@ class Driver(object):
 
         print("========== [%s] ==========" % title)
 
-        line, length = 0, 8
+        line, length = 0, 16
         while data:
             print('%04X' % line, *('%02X' % byte for byte in data[:length]))
             data = data[length:]

--- a/src/ant/core/event.py
+++ b/src/ant/core/event.py
@@ -33,7 +33,7 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 from time import sleep, time
 from threading import Lock, Thread
 
-from ant.core.constants import MESSAGE_TX_SYNC, RESPONSE_NO_ERROR
+from ant.core.constants import MESSAGE_TX_SYNC
 from ant.core.message import Message, ChannelEventResponseMessage
 from ant.core.exceptions import MessageError
 from usb.core import USBError
@@ -157,9 +157,7 @@ class EventMachine(object):
         return self
 
     def waitForAck(self, msg):
-        response = self.ack.waitFor(msg).messageCode
-        if response != RESPONSE_NO_ERROR:
-            raise MessageError("bad response code (%.2x)" % response, internal=(msg, response))
+        return self.ack.waitFor(msg).messageCode
 
     def waitForMessage(self, class_):
         return self.msg.waitFor(class_)

--- a/src/ant/core/message.py
+++ b/src/ant/core/message.py
@@ -372,6 +372,10 @@ class ChannelBroadcastDataMessage(ChannelMessage):
     def __init__(self, number=0x00, data=b'\x00' * 7):
         super(ChannelBroadcastDataMessage, self).__init__(payload=data, number=number)
 
+    @property
+    def data(self):
+        return self._payload[1:9]
+
 
 class ChannelAcknowledgedDataMessage(ChannelMessage):
     type = constants.MESSAGE_CHANNEL_ACKNOWLEDGED_DATA
@@ -379,12 +383,20 @@ class ChannelAcknowledgedDataMessage(ChannelMessage):
     def __init__(self, number=0x00, data=b'\x00' * 7):
         super(ChannelAcknowledgedDataMessage, self).__init__(payload=data, number=number)
 
+    @property
+    def data(self):
+        return self._payload[1:9]
+
 
 class ChannelBurstDataMessage(ChannelMessage):
     type = constants.MESSAGE_CHANNEL_BURST_DATA
 
     def __init__(self, number=0x00, data=b'\x00' * 7):
         super(ChannelBurstDataMessage, self).__init__(payload=data, number=number)
+
+    @property
+    def data(self):
+        return self._payload[1:9]
 
 
 # Channel event messages

--- a/src/ant/plus/heartrate.py
+++ b/src/ant/plus/heartrate.py
@@ -112,9 +112,9 @@ class HeartRate(DeviceProfile):
             self._previous_event_time = event_time
             self._accumulated_event_time += float(self.event_time_correction(time_difference)) / 1000
 
-        callback = self.callbacks.get('onHeartRateData')
-        if callback:
-            callback(self._computed_heart_rate, self._accumulated_event_time, rr_interval)
+            callback = self.callbacks.get('onHeartRateData')
+            if callback:
+                callback(self._computed_heart_rate, self._accumulated_event_time, rr_interval)
 
     @property
     def computed_heart_rate(self):

--- a/src/ant/plus/plus.py
+++ b/src/ant/plus/plus.py
@@ -106,7 +106,7 @@ class DeviceProfile(object):
             difference = current - previous
         return difference
 
-    def process(self, msg):
+    def process(self, msg, channel):
         """Handles incoming channel messages
         Converts messages to ANT+ device specific data.
         """

--- a/src/ant/plus/plus.py
+++ b/src/ant/plus/plus.py
@@ -106,7 +106,7 @@ class DeviceProfile(object):
             difference = current - previous
         return difference
 
-    def process(self, msg, channel):
+    def process(self, msg):
         """Handles incoming channel messages
         Converts messages to ANT+ device specific data.
         """

--- a/src/ant/plus/plus.py
+++ b/src/ant/plus/plus.py
@@ -32,8 +32,7 @@ from threading import Lock
 from enum import Enum
 
 from ant.core.constants import *
-from ant.core.message import ChannelBroadcastDataMessage, ChannelRequestMessage, ChannelIDMessage, \
-    ChannelEventResponseMessage
+from ant.core.message import *
 from ant.core.node import ChannelID
 
 
@@ -111,11 +110,11 @@ class DeviceProfile(object):
         Converts messages to ANT+ device specific data.
         """
         if isinstance(msg, ChannelBroadcastDataMessage):
-            self.processData(msg.payload[1:])  # First byte of payload is the channel number
+            self.processData(msg.data)
 
             if not self._detected:
                 req_msg = ChannelRequestMessage(messageID=MESSAGE_CHANNEL_ID)
-                self.node.send(req_msg)
+                self.channel.send(req_msg)
                 self._detected = True
 
         elif isinstance(msg, ChannelIDMessage):

--- a/src/ant/plus/stride.py
+++ b/src/ant/plus/stride.py
@@ -74,6 +74,9 @@ class Stride(DeviceProfile):
             if device_page == 0x01:
                 stride_count_index = 6 + payload_offset
                 self._stride_count = data[stride_count_index]
+                callback = self.callbacks.get('onStrideCount')
+                if callback:
+                    callback(self._stride_count)
 
             elif device_page == 0x02:
                 print("page 2, template")
@@ -81,6 +84,9 @@ class Stride(DeviceProfile):
             elif device_page == 0x03:
                 calories_index = 6 + payload_offset
                 self._calories = data[calories_index]
+                callback = self.callbacks.get('onCalories')
+                if callback:
+                    callback(self._calories)
 
             elif device_page == 0x10:
                 print("page 16, Distance & Strides Since Battery Reset")
@@ -102,15 +108,6 @@ class Stride(DeviceProfile):
             elif device_page == 0x51:
                 self._sw_revision = data[3 + payload_offset]
                 self._serial_number = struct.unpack('>L', data[4 + payload_offset:8 + payload_offset])[0]
-
-        if device_page == 0x01:
-            callback = self.callbacks.get('onStrideCount')
-            if callback:
-                callback(self._stride_count)
-        if device_page == 0x02:
-            callback = self.callbacks.get('onCalories')
-            if callback:
-                callback(self._calories)
 
     @property
     def stride_count(self):

--- a/tests/ant/plus/fakes.py
+++ b/tests/ant/plus/fakes.py
@@ -86,10 +86,10 @@ class FakeNode(Node):
     running = property(lambda self: self._running,
                        set_running)
 
-    def reset(self):
+    def reset(self, wait=True):
         pass
 
-    def start(self):
+    def start(self, wait=True):
         self.running = True
 
     def stop(self):

--- a/tests/ant/plus/fakes.py
+++ b/tests/ant/plus/fakes.py
@@ -25,6 +25,7 @@
 ##############################################################################
 
 from ant.core.node import Node, Channel
+from ant.core.constants import RESPONSE_NO_ERROR
 
 class FakeEventMachine():
     def __init__(self):
@@ -36,7 +37,7 @@ class FakeEventMachine():
         return self
 
     def waitForAck(self, msg):
-        return None
+        return RESPONSE_NO_ERROR
 
     def waitForMessage(self, class_):
         return self.waited_message

--- a/tests/ant/plus/test_heartrate.py
+++ b/tests/ant/plus/test_heartrate.py
@@ -198,6 +198,7 @@ class HeartRateTest(unittest.TestCase):
 
         hr.channel.process(ChannelIDMessage(0, 23358, 120, 1))
 
+        self.assertIsNotNone(channelId)
         self.assertEqual(23358, channelId.deviceNumber)
         self.assertEqual(120, channelId.deviceType)
         self.assertEqual(1, channelId.transmissionType)


### PR DESCRIPTION
Sam's change to throw an error on any response other than RESPONSE_NO_ERROR may be problematic, as there are many other response codes (both success and error) that can be returned.

I could be wrong. The specific message that waitForAck waits for (Channel Response / Event (0x40) with MessageID == 1) may only ever return failure codes or RESPONSE_NO_ERROR. But I still think it's better to be on the safe side.