### PR TITLE
Match device bus and address

### DIFF
--- a/src/ant/core/driver.py
+++ b/src/ant/core/driver.py
@@ -172,10 +172,12 @@ class USB1Driver(Driver):
 
 class USB2Driver(Driver):
 
-    def __init__(self, idVendor=0x0fcf, idProduct=0x1008, log=None, debug=False):
+    def __init__(self, idVendor=0x0fcf, idProduct=0x1008, bus=None, address=None, log=None, debug=False):
         super(USB2Driver, self).__init__(log=log, debug=debug)
         self.idVendor = idVendor
         self.idProduct = idProduct
+        self.bus = bus
+        self.address = address
 
         self._epOut = None
         self._epIn = None
@@ -184,7 +186,9 @@ class USB2Driver(Driver):
 
     def _open(self):
         # Most of this is straight from the PyUSB example documentation
-        dev = findDeviceUSB(idVendor=self.idVendor, idProduct=self.idProduct)
+        dev = findDeviceUSB(idVendor=self.idVendor, idProduct=self.idProduct,
+            custom_match=lambda d: (d.bus == self.bus or self.bus is None) and
+            (d.address == self.address or self.address is None))
 
         if dev is None:
             raise DriverError("Could not open device (not found)")


### PR DESCRIPTION
to deal with multiple identical devices, e.g.
```
    devs = find(find_all=True, idVendor=0x0fcf)
    for dev in devs:
        if dev.idProduct in [0x1008, 0x1009]:
            stick = driver.USB2Driver(log=LOG, debug=DEBUG, idProduct=dev.idProduct, bus=dev.bus, address=dev.address)
            try:
                stick.open()
            except:
                continue
            stick.close()
            break
    else:
        print("No ANT devices available")
        sys.exit()
```